### PR TITLE
Implement DF-HGNN deterministic features and training pipeline

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -34,6 +34,8 @@ features:
     spectral_topk: 32
     use_spectral: true
     use_hodge: false
+    use_temporal: true
+    quantile_clip: 0.01
     cache_dir: ${work_dir}/features
 
 optimizer:

--- a/scripts/train_df_hgnn.py
+++ b/scripts/train_df_hgnn.py
@@ -83,6 +83,8 @@ def main() -> None:
             spectral_topk=cfg["features"]["deterministic"].get("spectral_topk", 32),
             use_spectral=cfg["features"]["deterministic"].get("use_spectral", True),
             use_hodge=cfg["features"]["deterministic"].get("use_hodge", False),
+            use_temporal=cfg["features"]["deterministic"].get("use_temporal", True),
+            quantile_clip=cfg["features"]["deterministic"].get("quantile_clip", 0.01),
             cache_dir=cfg["features"]["deterministic"].get("cache_dir"),
         ),
         optimizer_config=OptimizerConfig(
@@ -102,6 +104,7 @@ def main() -> None:
         labels=data.labels,
         splits={"train": splits.train_idx, "val": splits.val_idx, "test": splits.test_idx},
         num_classes=int(cfg.get("num_classes", data.labels.max().item() + 1)),
+        timestamps=data.timestamps,
     )
 
     report_path = save_metrics_report(metrics, cfg["reporting"].get("dir", "outputs/reports"))

--- a/src/data/loaders/base.py
+++ b/src/data/loaders/base.py
@@ -14,7 +14,7 @@ class HypergraphData:
     num_nodes: int
     incidence: torch.Tensor  # dense or sparse N x E
     edge_weights: torch.Tensor
-    node_features: torch.Tensor
+    node_features: Optional[torch.Tensor]
     labels: Optional[torch.Tensor]
     timestamps: Optional[torch.Tensor]
     metadata: Dict[str, object]

--- a/src/features/deterministic_bank.py
+++ b/src/features/deterministic_bank.py
@@ -3,11 +3,33 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import numpy as np
 import torch
 from torch import Tensor
+
+
+def _quantile_clip(features: Tensor, clip: float) -> Tensor:
+    """Clip features using per-dimension quantiles."""
+
+    if features.numel() == 0:
+        return features
+    lower = torch.quantile(features, clip, dim=0, keepdim=True)
+    upper = torch.quantile(features, 1.0 - clip, dim=0, keepdim=True)
+    return torch.clamp(features, lower, upper)
+
+
+def robust_standardize(features: Tensor, clip: float) -> Tensor:
+    """Apply quantile clipping followed by zero-mean/unit-variance scaling."""
+
+    if features.numel() == 0:
+        return features
+    clipped = _quantile_clip(features, clip)
+    mean = clipped.mean(dim=0, keepdim=True)
+    std = clipped.std(dim=0, keepdim=True).clamp(min=1e-6)
+    standardized = (clipped - mean) / std
+    return torch.nan_to_num(standardized)
 
 
 @dataclass
@@ -15,67 +37,123 @@ class DeterministicFeatureConfig:
     spectral_topk: int = 32
     use_spectral: bool = True
     use_hodge: bool = False
+    use_temporal: bool = True
+    quantile_clip: float = 0.01
     cache_dir: Optional[str] = None
 
 
 class DeterministicFeatureBank:
+    """Collection of reproducible hypergraph descriptors."""
+
     def __init__(self, config: DeterministicFeatureConfig) -> None:
         self.config = config
 
-    def __call__(self, incidence: Tensor, edge_weights: Tensor) -> Tensor:
-        cache = self._load_cache(incidence)
+    def __call__(
+        self,
+        incidence: Tensor,
+        edge_weights: Tensor,
+        timestamps: Optional[Tensor] = None,
+    ) -> Tensor:
+        cache = self._load_cache(incidence, timestamps)
         if cache is not None:
             return cache
 
-        features = [self._node_degree(incidence, edge_weights), self._avg_edge_cardinality(incidence)]
+        features = [
+            self._hyperdegree(incidence, edge_weights),
+            self._incident_cardinality_stats(incidence),
+            self._expansion_graph_descriptors(incidence, edge_weights),
+        ]
+
         if self.config.use_spectral:
-            features.append(self._spectral_embeddings(incidence, edge_weights, self.config.spectral_topk))
+            features.append(
+                self._spectral_embeddings(
+                    incidence, edge_weights, self.config.spectral_topk
+                )
+            )
         if self.config.use_hodge:
-            features.append(self._hodge_proxy(incidence))
+            features.append(self._hodge_proxies(incidence, edge_weights))
+        if self.config.use_temporal and timestamps is not None:
+            features.append(self._temporal_statistics(incidence, timestamps))
 
         combined = torch.cat(features, dim=1)
-        combined = self._standardize(combined)
-        self._save_cache(incidence, combined)
+        combined = robust_standardize(combined, self.config.quantile_clip)
+        self._save_cache(incidence, timestamps, combined)
         return combined
 
-    def _node_degree(self, incidence: Tensor, edge_weights: Tensor) -> Tensor:
-        degrees = torch.matmul(incidence, edge_weights.unsqueeze(1))
-        return degrees
+    def _hyperdegree(self, incidence: Tensor, edge_weights: Tensor) -> Tensor:
+        weighted_degree = incidence @ edge_weights.unsqueeze(1)
+        unweighted_degree = incidence.gt(0).sum(dim=1, keepdim=True).to(weighted_degree.dtype)
+        return torch.cat([weighted_degree, unweighted_degree], dim=1)
 
-    def _avg_edge_cardinality(self, incidence: Tensor) -> Tensor:
+    def _incident_cardinality_stats(self, incidence: Tensor) -> Tensor:
         edge_sizes = incidence.sum(dim=0, keepdim=True)
-        node_edge_counts = (incidence > 0).sum(dim=1, keepdim=True).clamp(min=1)
-        avg_cardinality = torch.matmul(incidence, 1.0 / edge_sizes.t()) / node_edge_counts
-        return avg_cardinality
+        mask = incidence.gt(0)
+        node_edge_counts = (
+            mask.sum(dim=1, keepdim=True).to(dtype=incidence.dtype).clamp(min=1.0)
+        )
+        edge_sizes_expanded = edge_sizes.expand_as(incidence)
+        masked_sizes = torch.where(mask, edge_sizes_expanded, torch.zeros_like(edge_sizes_expanded))
+        mean = masked_sizes.sum(dim=1, keepdim=True) / node_edge_counts
+        centered = torch.where(mask, masked_sizes - mean, torch.zeros_like(masked_sizes))
+        var = (centered**2).sum(dim=1, keepdim=True) / node_edge_counts
+        return torch.cat([mean, var], dim=1)
 
-    def _spectral_embeddings(self, incidence: Tensor, edge_weights: Tensor, topk: int) -> Tensor:
+    def _expansion_graph_descriptors(self, incidence: Tensor, edge_weights: Tensor) -> Tensor:
+        edge_sizes = incidence.sum(dim=0).clamp(min=1.0)
+        pair_scaling = edge_weights / (edge_sizes - 1.0).clamp(min=1.0)
+        weighted_incidence = incidence * pair_scaling.unsqueeze(0)
+        adjacency = weighted_incidence @ incidence.t()
+        adjacency = (adjacency + adjacency.t()) * 0.5
+        adjacency.fill_diagonal_(0.0)
+        clique_degree = adjacency.sum(dim=1, keepdim=True)
+        star_degree = incidence.sum(dim=1, keepdim=True)
+        triangles = (adjacency @ adjacency * adjacency).sum(dim=1, keepdim=True) / 2.0
+        clustering = triangles / (clique_degree.clamp(min=1.0) * (clique_degree.clamp(min=1.0) - 1.0) + 1e-6)
+        return torch.cat([star_degree, clique_degree, clustering], dim=1)
+
+    def _spectral_embeddings(
+        self, incidence: Tensor, edge_weights: Tensor, topk: int
+    ) -> Tensor:
         theta = self._normalized_operator(incidence, edge_weights)
-        evals, evecs = torch.linalg.eigh(theta + 1e-6 * torch.eye(theta.shape[0], device=theta.device))
+        identity = torch.eye(theta.shape[0], device=theta.device, dtype=theta.dtype)
+        _, evecs = torch.linalg.eigh(theta + 1e-6 * identity)
         k = min(topk, evecs.shape[1])
         return evecs[:, -k:]
 
-    def _hodge_proxy(self, incidence: Tensor) -> Tensor:
-        edge_sizes = incidence.sum(dim=0)
-        normalized = incidence / edge_sizes.clamp(min=1.0)
-        return normalized @ normalized.t()
+    def _hodge_proxies(self, incidence: Tensor, edge_weights: Tensor) -> Tensor:
+        weighted_incidence = incidence * edge_weights.unsqueeze(0)
+        gram = weighted_incidence @ weighted_incidence.t()
+        cycle_strength = torch.diag(gram).unsqueeze(1)
+        flux_strength = weighted_incidence.std(dim=1, keepdim=True)
+        return torch.cat([cycle_strength, flux_strength], dim=1)
 
-    def _standardize(self, features: Tensor) -> Tensor:
-        mean = features.mean(dim=0, keepdim=True)
-        std = features.std(dim=0, keepdim=True).clamp(min=1e-6)
-        standardized = (features - mean) / std
-        return torch.nan_to_num(standardized)
+    def _temporal_statistics(self, incidence: Tensor, timestamps: Tensor) -> Tensor:
+        timestamps = timestamps.to(dtype=incidence.dtype)
+        mask = incidence.gt(0)
+        node_counts = mask.sum(dim=1, keepdim=True).to(dtype=incidence.dtype)
+        node_counts_clamped = node_counts.clamp(min=1.0)
+        ts_matrix = timestamps.unsqueeze(0).expand_as(incidence)
+        masked_ts = torch.where(mask, ts_matrix, torch.zeros_like(ts_matrix))
+        mean_time = masked_ts.sum(dim=1, keepdim=True) / node_counts_clamped
+        centered = torch.where(mask, ts_matrix - mean_time, torch.zeros_like(ts_matrix))
+        var_time = (centered**2).sum(dim=1, keepdim=True) / node_counts_clamped
+        duration = timestamps.max() - timestamps.min() + 1e-6
+        interaction_rate = node_counts / duration
+        stability = 1.0 / (1.0 + var_time)
+        return torch.cat([interaction_rate, mean_time / duration, stability], dim=1)
 
     def _normalized_operator(self, incidence: Tensor, edge_weights: Tensor) -> Tensor:
-        node_degree = torch.matmul(incidence, edge_weights.unsqueeze(1)).flatten()
+        node_degree = (incidence @ edge_weights.unsqueeze(1)).flatten()
         edge_degree = incidence.sum(dim=0)
         d_v_inv_sqrt = torch.diag(torch.pow(node_degree.clamp(min=1e-6), -0.5))
         d_e_inv = torch.diag(torch.pow(edge_degree.clamp(min=1.0), -1.0))
         w_diag = torch.diag(edge_weights)
-        theta = d_v_inv_sqrt @ incidence @ w_diag @ d_e_inv @ incidence.t() @ d_v_inv_sqrt
-        return theta
+        return d_v_inv_sqrt @ incidence @ w_diag @ d_e_inv @ incidence.t() @ d_v_inv_sqrt
 
-    def _cache_path(self, incidence: Tensor) -> Optional[Path]:
-        if not self.config.cache_dir:
+    def _cache_path(
+        self, incidence: Tensor, timestamps: Optional[Tensor]
+    ) -> Optional[Path]:
+        if not self.config.cache_dir or (timestamps is not None and self.config.use_temporal):
             return None
         num_nodes, num_edges = incidence.shape
         identifier = f"det_{num_nodes}_{num_edges}.npz"
@@ -83,14 +161,18 @@ class DeterministicFeatureBank:
         path.mkdir(parents=True, exist_ok=True)
         return path / identifier
 
-    def _load_cache(self, incidence: Tensor) -> Optional[Tensor]:
-        cache_path = self._cache_path(incidence)
+    def _load_cache(
+        self, incidence: Tensor, timestamps: Optional[Tensor]
+    ) -> Optional[Tensor]:
+        cache_path = self._cache_path(incidence, timestamps)
         if cache_path and cache_path.exists():
             data = np.load(cache_path)
             return torch.tensor(data["features"], dtype=torch.float32)
         return None
 
-    def _save_cache(self, incidence: Tensor, features: Tensor) -> None:
-        cache_path = self._cache_path(incidence)
+    def _save_cache(
+        self, incidence: Tensor, timestamps: Optional[Tensor], features: Tensor
+    ) -> None:
+        cache_path = self._cache_path(incidence, timestamps)
         if cache_path:
             np.savez_compressed(cache_path, features=features.cpu().numpy())

--- a/src/models/df_hgnn.py
+++ b/src/models/df_hgnn.py
@@ -23,30 +23,64 @@ class DFHGNNConfig:
     chebyshev_order: int = 2
     lambda_align: float = 0.1
     lambda_gate: float = 0.001
+    fusion_dim: int | None = None
 
 
 class DFHGNN(nn.Module):
     def __init__(self, config: DFHGNNConfig) -> None:
         super().__init__()
-        half_hidden = config.hidden_dim // 2
         self.config = config
-        self.phi = nn.Linear(config.det_dim, half_hidden)
-        self.psi = nn.Linear(config.in_dim, half_hidden)
-        self.gate = nn.Sequential(
-            nn.Linear(half_hidden * 2, config.hidden_dim),
-            nn.ReLU(),
-            nn.Linear(config.hidden_dim, half_hidden),
-        )
+        fusion_dim = config.fusion_dim or max(1, config.hidden_dim // 2)
+        self.fusion_dim = fusion_dim
+
+        self.has_raw = config.in_dim > 0
+        self.has_det = config.det_dim > 0
+        if not self.has_raw and not self.has_det:
+            raise ValueError("DF-HGNN requires at least one feature source")
+
+        if self.has_det:
+            self.phi = nn.Sequential(
+                nn.Linear(config.det_dim, fusion_dim),
+                nn.ReLU(),
+            )
+        else:
+            self.phi = None
+
+        if self.has_raw:
+            self.psi = nn.Sequential(
+                nn.Linear(config.in_dim, fusion_dim),
+                nn.ReLU(),
+            )
+        else:
+            self.psi = None
+
+        gate_input = 0
+        if self.has_raw:
+            gate_input += fusion_dim
+        if self.has_det:
+            gate_input += fusion_dim
+
+        if self.has_raw and self.has_det:
+            self.gate = nn.Sequential(
+                nn.Linear(gate_input, config.hidden_dim),
+                nn.ReLU(),
+                nn.Linear(config.hidden_dim, fusion_dim),
+            )
+        else:
+            self.gate = None
+
         if config.conv_type == "cheb":
-            self.conv1 = HypergraphChebConv(half_hidden, config.hidden_dim, K=config.chebyshev_order)
+            self.conv1 = HypergraphChebConv(fusion_dim, config.hidden_dim, K=config.chebyshev_order)
             self.conv2 = HypergraphChebConv(config.hidden_dim, config.hidden_dim, K=config.chebyshev_order)
         else:
-            self.conv1 = HypergraphMPConv(half_hidden, config.hidden_dim)
+            self.conv1 = HypergraphMPConv(fusion_dim, config.hidden_dim)
             self.conv2 = HypergraphMPConv(config.hidden_dim, config.hidden_dim)
         self.dropout = nn.Dropout(config.dropout)
         self.output = nn.Linear(config.hidden_dim, config.out_dim)
 
-    def forward(self, x: Tensor, z: Tensor, incidence: Tensor, edge_weights: Tensor) -> Tuple[Tensor, Tensor]:
+    def forward(
+        self, x: Tensor, z: Tensor, incidence: Tensor, edge_weights: Tensor
+    ) -> Tuple[Tensor, Tensor]:
         fused, gate = self._fuse_features(x, z)
         h = self.conv1(fused, incidence, edge_weights)
         h = F.relu(h)
@@ -57,18 +91,45 @@ class DFHGNN(nn.Module):
         logits = self.output(h)
         return logits, gate
 
+    def _project_raw(self, x: Tensor) -> Tensor | None:
+        if not self.has_raw:
+            return None
+        if x.numel() == 0:
+            return None
+        return self.psi(x)
+
+    def _project_det(self, z: Tensor) -> Tensor | None:
+        if not self.has_det:
+            return None
+        return self.phi(z)
+
     def _fuse_features(self, x: Tensor, z: Tensor) -> Tuple[Tensor, Tensor]:
-        proj_x = self.psi(x)
-        proj_z = self.phi(z)
-        gate_logits = self.gate(torch.cat([proj_x, proj_z], dim=1))
-        gate = torch.sigmoid(gate_logits)
-        fused = gate * proj_z + (1 - gate) * proj_x
+        proj_x = self._project_raw(x)
+        proj_z = self._project_det(z)
+
+        if proj_x is None and proj_z is None:
+            raise ValueError("At least one feature projection must be available")
+
+        if proj_x is None:
+            fused = proj_z
+            gate = torch.ones_like(fused)
+        elif proj_z is None:
+            fused = proj_x
+            gate = torch.zeros_like(fused)
+        else:
+            gate_logits = self.gate(torch.cat([proj_z, proj_x], dim=1))
+            gate = torch.sigmoid(gate_logits)
+            fused = gate * proj_z + (1 - gate) * proj_x
         return fused, gate
 
     def alignment_loss(self, x: Tensor, z: Tensor) -> Tensor:
-        proj_x = F.normalize(self.psi(x), dim=1)
-        proj_z = F.normalize(self.phi(z), dim=1)
+        if not (self.has_raw and self.has_det):
+            return torch.tensor(0.0, device=z.device, dtype=z.dtype)
+        proj_x = F.normalize(self._project_raw(x), dim=1)
+        proj_z = F.normalize(self._project_det(z), dim=1)
         return F.mse_loss(proj_x, proj_z)
 
     def gate_regularization(self, gate: Tensor) -> Tensor:
-        return gate.mean()
+        if not (self.has_raw and self.has_det):
+            return gate.new_tensor(0.0)
+        return gate.abs().mean()

--- a/src/models/registry.py
+++ b/src/models/registry.py
@@ -18,6 +18,7 @@ class ModelFactoryInput:
     chebyshev_order: int
     lambda_align: float
     lambda_gate: float
+    fusion_dim: int | None = None
 
 
 def create_model(name: str, config: ModelFactoryInput):
@@ -32,6 +33,7 @@ def create_model(name: str, config: ModelFactoryInput):
             chebyshev_order=config.chebyshev_order,
             lambda_align=config.lambda_align,
             lambda_gate=config.lambda_gate,
+            fusion_dim=config.fusion_dim,
         )
         return DFHGNN(df_config)
     raise ValueError(f"Unknown model name: {name}")


### PR DESCRIPTION
## Summary
- extend the deterministic feature bank with structural, spectral, and temporal statistics plus robust scaling and caching controls
- update DF-HGNN fusion/gating to support optional raw attributes, configurable fusion dims, and propagate alignment and gate penalties through both optimizers
- refresh trainer, registry, and CLI configuration to preprocess raw features, surface new feature-bank options, and pass dataset timestamps

## Testing
- python -m compileall src
- pytest tests/unit/test_deterministic_features.py -q *(fails: torch is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db53c5e51c8323a01d9c2ce40d776f