### PR TITLE
Fix deterministic feature tensors from deterministic feature bank

### DIFF
--- a/src/features/deterministic_bank.py
+++ b/src/features/deterministic_bank.py
@@ -100,6 +100,12 @@ class DeterministicFeatureBank:
             combined = torch.cat(features, dim=1)
             combined = robust_standardize(combined, self.config.quantile_clip)
 
+        # ``torch.inference_mode`` produces tensors that cannot participate in
+        # autograd.  Downstream training reuses the deterministic features as
+        # standard tensors, so make an explicit clone outside the context to
+        # drop the inference flag and gradients.
+        combined = combined.clone().detach()
+
         self._save_cache(incidence, timestamps, combined)
         return combined
 


### PR DESCRIPTION
## Summary
- clone and detach deterministic feature bank outputs after inference mode so downstream training can backpropagate
- document why the clone is required to drop the inference flag

## Testing
- pytest tests -q

------
https://chatgpt.com/codex/tasks/task_e_68dc0df9ea6c83239b8640d6b5e11020