### PR TITLE
Fix default email-Eu-full config paths

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -52,6 +52,10 @@ optimizer:
 data:
   name: email_eu_full
   root: data/raw/email-Eu-full
+  files:
+    vertices: email-Eu-full-nverts.txt
+    simplices: email-Eu-full-simplices.txt
+    times: email-Eu-full-times.txt
   label_file: email-Eu-full-labels.npy
   task: node_classification
   split:


### PR DESCRIPTION
## Summary
- add the required raw dataset file paths to the default email-Eu-full configuration so the loader can be constructed

## Testing
- pytest tests/unit/test_email_eu_full_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68dc2d9a99d48323b03d86796bb6322a