### PR TITLE
Handle renamed dataset artifacts and compose experiment configs

### DIFF
--- a/configs/data/cat_edge_dawn.yaml
+++ b/configs/data/cat_edge_dawn.yaml
@@ -2,9 +2,7 @@ name: cat_edge_dawn
 root: data/raw/cat-edge-DAWN
 files:
   simplices: cat-edge-DAWN-simplices.txt
-  features: cat-edge-DAWN-node-features.npy
-  labels: cat-edge-DAWN-node-labels.npy
-  times: cat-edge-DAWN-times.txt
+  labels: cat-edge-DAWN-node-labels.txt
 metadata:
   description: "Dynamic attribute-weighted network of collaborative tagging"
   citation: "Wang et al., 2020"

--- a/configs/data/coauth_dblp_full.yaml
+++ b/configs/data/coauth_dblp_full.yaml
@@ -2,8 +2,8 @@ name: coauth_dblp_full
 root: data/raw/coauth-DBLP-full
 files:
   simplices: coauth-DBLP-full-simplices.txt
-  features: coauth-DBLP-full-node-features.npy
-  labels: coauth-DBLP-full-node-labels.npy
+  labels: coauth-DBLP-full-node-labels.txt
+  times: coauth-DBLP-full-times.txt
 metadata:
   description: "Full DBLP co-authorship hypergraph with publication venues"
   citation: "Li et al., 2021"

--- a/configs/data/stackoverflow_answers.yaml
+++ b/configs/data/stackoverflow_answers.yaml
@@ -1,9 +1,9 @@
 name: stackoverflow_answers
 root: data/raw/stackoverflow-answers
 files:
-  simplices: hyperedges-stackoverflow-answers.txt
-  labels: node-labels-stackoverflow-answers.txt
-  label_names: label-names-stackoverflow-answers.txt
+  simplices: stackoverflow-answers-hyperedges.txt
+  labels: stackoverflow-answers-node-labels.txt
+  label_names: stackoverflow-answers-label-names.txt
 metadata:
   description: "StackOverflow answer interactions with topic annotations"
   citation: "Ghosh et al., 2019"

--- a/configs/experiment/coauth_dblp_transfer.yaml
+++ b/configs/experiment/coauth_dblp_transfer.yaml
@@ -30,8 +30,8 @@ data:
     target_name: stackoverflow_answers
     target_root: data/raw/stackoverflow-answers
     target_files:
-      simplices: hyperedges-stackoverflow-answers.txt
-      labels: node-labels-stackoverflow-answers.txt
+      simplices: stackoverflow-answers-hyperedges.txt
+      labels: stackoverflow-answers-node-labels.txt
     split:
       strategy: stratified
       train_ratio: 0.5

--- a/docs/data-spec.md
+++ b/docs/data-spec.md
@@ -42,8 +42,8 @@
 | 数据集 | 目录 | 关键文件 | 推荐任务 |
 | --- | --- | --- | --- |
 | email-Eu-full | `data/raw/email-Eu-full/` | `*-nverts.txt`, `*-simplices.txt`, `*-times.txt`, `*-labels.npy` | 节点分类、超边预测 |
-| cat-edge-DAWN | `data/raw/cat-edge-DAWN/` | `cat-edge-DAWN-simplices.txt`, 可选 `cat-edge-DAWN-node-features.npy`, `cat-edge-DAWN-node-labels.npy`, `cat-edge-DAWN-times.txt` | 低标注率节点分类、时间感知预测 |
-| coauth-DBLP-full | `data/raw/coauth-DBLP-full/` | `coauth-DBLP-full-simplices.txt`, 可选 `coauth-DBLP-full-node-features.npy`, `coauth-DBLP-full-node-labels.npy` | 跨域迁移、社区检测 |
-| stackoverflow-answers | `data/raw/stackoverflow-answers/` | `hyperedges-stackoverflow-answers.txt`, `node-labels-stackoverflow-answers.txt`, `label-names-stackoverflow-answers.txt` | OOD 节点分类、超边预测 |
+| cat-edge-DAWN | `data/raw/cat-edge-DAWN/` | `cat-edge-DAWN-simplices.txt`, `cat-edge-DAWN-node-labels.txt` | 低标注率节点分类、时间感知预测 |
+| coauth-DBLP-full | `data/raw/coauth-DBLP-full/` | `coauth-DBLP-full-simplices.txt`, `coauth-DBLP-full-node-labels.txt`, `coauth-DBLP-full-times.txt` | 跨域迁移、社区检测 |
+| stackoverflow-answers | `data/raw/stackoverflow-answers/` | `stackoverflow-answers-hyperedges.txt`, `stackoverflow-answers-node-labels.txt`, `stackoverflow-answers-label-names.txt` | OOD 节点分类、超边预测 |
 
 > 注意：仓库中以 Git LFS 指针形式存储的大文件需要在本地执行 `git lfs pull` 后方可由上述脚本读取；未提供的可选文件请在配置中将对应条目设为 `null`。

--- a/scripts/preprocess_cat_edge_dawn.py
+++ b/scripts/preprocess_cat_edge_dawn.py
@@ -36,19 +36,19 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--features-file",
         type=str,
-        default="cat-edge-DAWN-node-features.npy",
+        default="",
         help="Relative path to node features (optional)",
     )
     parser.add_argument(
         "--labels-file",
         type=str,
-        default="cat-edge-DAWN-node-labels.npy",
-        help="Relative path to node labels (optional)",
+        default="cat-edge-DAWN-node-labels.txt",
+        help="Relative path to node labels",
     )
     parser.add_argument(
         "--times-file",
         type=str,
-        default="cat-edge-DAWN-times.txt",
+        default="",
         help="Relative path to hyperedge timestamps (optional)",
     )
     return parser.parse_args()

--- a/scripts/preprocess_coauth_dblp_full.py
+++ b/scripts/preprocess_coauth_dblp_full.py
@@ -36,14 +36,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--features-file",
         type=str,
-        default="coauth-DBLP-full-node-features.npy",
+        default="",
         help="Relative path to node features (optional)",
     )
     parser.add_argument(
         "--labels-file",
         type=str,
-        default="coauth-DBLP-full-node-labels.npy",
-        help="Relative path to node labels (optional)",
+        default="coauth-DBLP-full-node-labels.txt",
+        help="Relative path to node labels",
     )
     parser.add_argument(
         "--times-file",

--- a/scripts/preprocess_stackoverflow_answers.py
+++ b/scripts/preprocess_stackoverflow_answers.py
@@ -33,13 +33,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--simplices-file",
         type=str,
-        default="hyperedges-stackoverflow-answers.txt",
+        default="stackoverflow-answers-hyperedges.txt",
         help="Relative path to hyperedge list",
     )
     parser.add_argument(
         "--labels-file",
         type=str,
-        default="node-labels-stackoverflow-answers.txt",
+        default="stackoverflow-answers-node-labels.txt",
         help="Relative path to node labels",
     )
     parser.add_argument(

--- a/src/data/loaders/stackoverflow_answers.py
+++ b/src/data/loaders/stackoverflow_answers.py
@@ -18,7 +18,7 @@ class StackOverflowAnswersConfig(EdgeListHypergraphConfig):
 
     comment_prefix: str = "%"
     min_cardinality: int = 2
-    label_file: Optional[str] = "node-labels-stackoverflow-answers.txt"
+    label_file: Optional[str] = "stackoverflow-answers-node-labels.txt"
 
 
 class StackOverflowAnswersLoader(EdgeListHypergraphLoader):


### PR DESCRIPTION
## Summary
- add lightweight Hydra-style default resolution to `train_df_hgnn.py` so experiment configs expand their defaults and merge with `default.yaml`
- update dataset and experiment configs, preprocess scripts, and loader defaults to match the renamed raw files for Cat-Edge-DAWN, coauth-DBLP-full, and StackOverflow Answers
- refresh the data specification table to document the new artifact names

## Testing
- `python - <<'PY'
from scripts.train_df_hgnn import load_config
cfg = load_config('configs/experiment/cat_edge_dawn_low_label.yaml')
print(cfg['data']['root'])
print(cfg['data']['files'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68dc50b491bc8323be716af987b1b193