### PR TITLE
Improve dataset loading resilience for new benchmarks

### DIFF
--- a/tests/unit/test_generic_loader.py
+++ b/tests/unit/test_generic_loader.py
@@ -1,0 +1,41 @@
+"""Tests for the generic hypergraph loader utilities."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from src.data.loaders.generic import EdgeListHypergraphConfig, EdgeListHypergraphLoader
+
+
+def _write_lines(path: Path, lines: list[str]) -> None:
+    path.write_text("\n".join(lines))
+
+
+def test_generic_loader_skips_small_hyperedges(tmp_path, caplog: pytest.LogCaptureFixture) -> None:
+    simplices_path = Path(tmp_path) / "simplices.txt"
+    _write_lines(simplices_path, ["0 1", "2", "3 4 5", "# comment"])
+
+    config = EdgeListHypergraphConfig(simplices_file="simplices.txt", min_cardinality=2)
+    loader = EdgeListHypergraphLoader(str(tmp_path), config)
+
+    with caplog.at_level(logging.WARNING):
+        simplices = loader._read_simplices(simplices_path)
+
+    assert simplices == [[0, 1], [3, 4, 5]]
+    assert "Dropped 1 hyperedges" in caplog.text
+
+
+def test_generic_loader_detects_git_lfs_pointer(tmp_path) -> None:
+    simplices_path = Path(tmp_path) / "simplices.txt"
+    _write_lines(
+        simplices_path,
+        ["version https://git-lfs.github.com/spec/v1", "oid sha256:123", "size 42"],
+    )
+
+    config = EdgeListHypergraphConfig(simplices_file="simplices.txt")
+    loader = EdgeListHypergraphLoader(str(tmp_path), config)
+
+    with pytest.raises(RuntimeError, match="Git LFS"):
+        loader._read_simplices(simplices_path)

--- a/tests/unit/test_path_utils.py
+++ b/tests/unit/test_path_utils.py
@@ -1,6 +1,7 @@
 """Tests for dataset root resolution utilities."""
 from __future__ import annotations
 
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -87,4 +88,20 @@ def test_resolution_error_lists_attempts(tmp_path: Path) -> None:
     message = str(exc_info.value)
     assert "missing" in message
     assert "project" in message
+
+
+def test_resolve_extracts_zip_archive(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    data_root = project_root / "data" / "raw"
+    data_root.mkdir(parents=True)
+
+    archive_path = data_root / "dataset.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("dataset/file.txt", "payload")
+
+    resolved = resolve_dataset_root("data/raw/dataset", project_root=project_root)
+
+    assert resolved == data_root / "dataset"
+    assert (resolved / "file.txt").read_text() == "payload"
 


### PR DESCRIPTION
## Summary
- automatically extract dataset archives when resolving dataset roots
- relax hyperedge parsing by skipping too-small simplices and detecting Git LFS placeholders
- add unit tests covering archive extraction and the new loader behaviours

## Testing
- pytest tests/unit/test_generic_loader.py tests/unit/test_path_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6e6da82c8323a6bde8d6769a945c