### PR TITLE
Add baseline hypergraph models and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ in the `model` section of the config.
 - Toggle `trainer.pin_memory` to optimise host-to-device transfers when running on GPU.
 - Modify `data.split` to alter the train/validation/test ratios or use random splits.
 
+## Baseline implementations
+
+Alongside DF-HGNN we provide three baseline encoders that share the same feature pipeline and
+training loop (invoke them with `python scripts/train_df_hgnn.py --config <experiment.yaml>`):
+
+- **AllSet Transformer** (Chien et al., NeurIPS 2022) relies on multi-head attention between
+  node and hyperedge representations. Our default run uses a 160-dimensional hidden size, three
+  transformer blocks with four heads, and an MLP expansion ratio of 2.0.【F:configs/experiment/allset_transformer.yaml†L1-L15】
+- **UniGNN** (Huang et al., NeurIPS 2021) couples edge and node updates with residual diffusion.
+  The reference configuration keeps three stacked layers with dropout 0.3 to mimic the published
+  setup.【F:configs/experiment/unignn.yaml†L1-L14】
+- **HyperGCN** (Yadati et al., NeurIPS 2019) builds a symmetric normalised Laplacian from the
+  incidence matrix and applies three diffusion layers with 0.25 dropout.【F:configs/experiment/hypergcn.yaml†L1-L14】
+
+All three variants depend only on PyTorch (no extra third-party packages) and reuse the deterministic
+feature computation shipped with DF-HGNN, enabling apples-to-apples comparisons across baselines.
+
 ### 5. Documentation & further reading
 
 See the documents in `docs/` for the theoretical motivation (`architecture.md`), planned

--- a/configs/experiment/allset_transformer.yaml
+++ b/configs/experiment/allset_transformer.yaml
@@ -1,0 +1,16 @@
+defaults:
+  - override /model: allset_transformer
+  - override /data: email_eu_full
+
+trainer:
+  max_epochs: 150
+  adam_epochs: 90
+  lbfgs_epochs: 20
+  early_stopping_patience: 20
+
+model:
+  hidden_dim: 160
+  dropout: 0.2
+  num_layers: 3
+  num_heads: 4
+  mlp_ratio: 2.0

--- a/configs/experiment/hypergcn.yaml
+++ b/configs/experiment/hypergcn.yaml
@@ -1,0 +1,14 @@
+defaults:
+  - override /model: hypergcn
+  - override /data: email_eu_full
+
+trainer:
+  max_epochs: 120
+  adam_epochs: 80
+  lbfgs_epochs: 20
+  early_stopping_patience: 20
+
+model:
+  hidden_dim: 128
+  dropout: 0.25
+  num_layers: 3

--- a/configs/experiment/unignn.yaml
+++ b/configs/experiment/unignn.yaml
@@ -1,0 +1,14 @@
+defaults:
+  - override /model: unignn
+  - override /data: email_eu_full
+
+trainer:
+  max_epochs: 140
+  adam_epochs: 100
+  lbfgs_epochs: 15
+  early_stopping_patience: 25
+
+model:
+  hidden_dim: 144
+  dropout: 0.3
+  num_layers: 3

--- a/configs/model/allset_transformer.yaml
+++ b/configs/model/allset_transformer.yaml
@@ -1,0 +1,6 @@
+name: allset_transformer
+hidden_dim: 128
+dropout: 0.2
+num_layers: 2
+num_heads: 4
+mlp_ratio: 2.0

--- a/configs/model/hypergcn.yaml
+++ b/configs/model/hypergcn.yaml
@@ -1,0 +1,4 @@
+name: hypergcn
+hidden_dim: 128
+dropout: 0.25
+num_layers: 2

--- a/configs/model/unignn.yaml
+++ b/configs/model/unignn.yaml
@@ -1,0 +1,4 @@
+name: unignn
+hidden_dim: 128
+dropout: 0.3
+num_layers: 3

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,16 @@
+"""Model exports for the DF-HGNN project."""
+from .allset_transformer import AllSetTransformer, AllSetTransformerConfig
+from .df_hgnn import DFHGNN, DFHGNNConfig
+from .hypergcn import HyperGCN, HyperGCNConfig
+from .unignn import UniGNN, UniGNNConfig
+
+__all__ = [
+    "AllSetTransformer",
+    "AllSetTransformerConfig",
+    "DFHGNN",
+    "DFHGNNConfig",
+    "HyperGCN",
+    "HyperGCNConfig",
+    "UniGNN",
+    "UniGNNConfig",
+]

--- a/src/models/allset_transformer.py
+++ b/src/models/allset_transformer.py
@@ -1,0 +1,103 @@
+"""AllSet Transformer baseline for hypergraph learning."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from torch import Tensor, nn
+
+from .baseline_utils import aggregate_edges, fuse_features, zero_gate
+
+
+@dataclass
+class AllSetTransformerConfig:
+    in_dim: int
+    det_dim: int
+    hidden_dim: int = 128
+    out_dim: int = 2
+    num_layers: int = 2
+    num_heads: int = 4
+    mlp_ratio: float = 2.0
+    dropout: float = 0.2
+
+
+class _AllSetTransformerBlock(nn.Module):
+    def __init__(self, hidden_dim: int, num_heads: int, mlp_ratio: float, dropout: float) -> None:
+        super().__init__()
+        self.attention = nn.MultiheadAttention(
+            embed_dim=hidden_dim, num_heads=num_heads, dropout=dropout, batch_first=True
+        )
+        mlp_hidden = max(hidden_dim, int(hidden_dim * mlp_ratio))
+        self.feedforward = nn.Sequential(
+            nn.Linear(hidden_dim, mlp_hidden),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(mlp_hidden, hidden_dim),
+        )
+        self.norm1 = nn.LayerNorm(hidden_dim)
+        self.norm2 = nn.LayerNorm(hidden_dim)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(
+        self, node_embeddings: Tensor, incidence: Tensor, edge_weights: Tensor | None
+    ) -> Tensor:
+        edge_embeddings = aggregate_edges(node_embeddings, incidence, edge_weights)
+        attn_output, _ = self.attention(
+            node_embeddings.unsqueeze(0),
+            edge_embeddings.unsqueeze(0),
+            edge_embeddings.unsqueeze(0),
+        )
+        attn_output = attn_output.squeeze(0)
+        h = self.norm1(node_embeddings + self.dropout(attn_output))
+        ff = self.feedforward(h)
+        h = self.norm2(h + self.dropout(ff))
+        return h
+
+
+class AllSetTransformer(nn.Module):
+    """A minimal AllSet Transformer implementation with a DF-HGNN compatible API."""
+
+    def __init__(self, config: AllSetTransformerConfig) -> None:
+        super().__init__()
+        self.config = config
+        input_dim = config.in_dim + config.det_dim
+        if input_dim <= 0:
+            raise ValueError("AllSet Transformer requires at least one feature dimension")
+
+        self.input_proj = nn.Linear(input_dim, config.hidden_dim)
+        self.blocks = nn.ModuleList(
+            [
+                _AllSetTransformerBlock(
+                    config.hidden_dim,
+                    config.num_heads,
+                    config.mlp_ratio,
+                    config.dropout,
+                )
+                for _ in range(config.num_layers)
+            ]
+        )
+        self.dropout = nn.Dropout(config.dropout)
+        self.output = nn.Linear(config.hidden_dim, config.out_dim)
+
+    def forward(
+        self, x: Tensor, z: Tensor, incidence: Tensor, edge_weights: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        fused = fuse_features(x, z)
+        h = self.input_proj(fused)
+        for block in self.blocks:
+            h = block(h, incidence, edge_weights)
+        h = self.dropout(h)
+        logits = self.output(h)
+        gate = zero_gate(h)
+        return logits, gate
+
+    def alignment_loss(self, x: Tensor, z: Tensor) -> Tensor:
+        reference = x if x is not None and x.numel() > 0 else z
+        if reference is None or reference.numel() == 0:
+            reference = next(self.parameters()).detach()
+        return reference.new_zeros(())
+
+    def gate_regularization(self, gate: Tensor) -> Tensor:
+        return gate.new_zeros(())
+
+
+__all__ = ["AllSetTransformer", "AllSetTransformerConfig"]

--- a/src/models/baseline_utils.py
+++ b/src/models/baseline_utils.py
@@ -1,0 +1,99 @@
+"""Utility helpers for baseline hypergraph models."""
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def fuse_features(x: Tensor, z: Tensor) -> Tensor:
+    """Concatenate raw and deterministic features when available."""
+    tensors = []
+    if x is not None and x.numel() > 0:
+        tensors.append(x)
+    if z is not None and z.numel() > 0:
+        tensors.append(z)
+    if not tensors:
+        raise ValueError("Baseline models require at least one input feature source")
+    return torch.cat(tensors, dim=1)
+
+
+def _prepare_edge_weights(
+    incidence: Tensor, edge_weights: Tensor | None, dtype: torch.dtype, device: torch.device
+) -> Tensor:
+    num_edges = incidence.shape[1]
+    if edge_weights is None or edge_weights.numel() == 0:
+        return torch.ones(num_edges, device=device, dtype=dtype)
+    weights = edge_weights.view(-1).to(device=device, dtype=dtype)
+    if weights.shape[0] != num_edges:
+        raise ValueError(
+            "Edge-weight vector must match the number of hyperedges: "
+            f"expected {num_edges}, got {weights.shape[0]}"
+        )
+    return weights
+
+
+def aggregate_edges(node_features: Tensor, incidence: Tensor, edge_weights: Tensor | None) -> Tensor:
+    """Project node representations to the hyperedge domain."""
+    dtype = node_features.dtype
+    device = node_features.device
+    weights = _prepare_edge_weights(incidence, edge_weights, dtype, device)
+    incidence = incidence.to(device=device, dtype=dtype)
+    weighted_incidence = incidence * weights.unsqueeze(0)
+    edge_deg = weighted_incidence.sum(dim=0, keepdim=True).clamp_min(1.0)
+    aggregated = (weighted_incidence.t() @ node_features) / edge_deg.t()
+    return aggregated
+
+
+def aggregate_nodes(edge_features: Tensor, incidence: Tensor, edge_weights: Tensor | None) -> Tensor:
+    """Diffuse hyperedge representations back to the node domain."""
+    dtype = edge_features.dtype
+    device = edge_features.device
+    weights = _prepare_edge_weights(incidence, edge_weights, dtype, device)
+    incidence = incidence.to(device=device, dtype=dtype)
+    weighted_incidence = incidence * weights.unsqueeze(0)
+    node_deg = weighted_incidence.sum(dim=1, keepdim=True).clamp_min(1.0)
+    aggregated = (weighted_incidence @ edge_features) / node_deg
+    return aggregated
+
+
+def hypergraph_normalised_adjacency(
+    incidence: Tensor, edge_weights: Tensor | None, dtype: torch.dtype, device: torch.device
+) -> Tensor:
+    """Compute the symmetric normalised adjacency used by HyperGCN."""
+    num_nodes, num_edges = incidence.shape
+    if num_edges == 0:
+        return torch.eye(num_nodes, device=device, dtype=dtype)
+
+    incidence = incidence.to(device=device, dtype=dtype)
+    weights = _prepare_edge_weights(incidence, edge_weights, dtype, device)
+
+    edge_degree = incidence.sum(dim=0).clamp_min(1.0)
+    node_degree = (incidence * weights.unsqueeze(0)).sum(dim=1).clamp_min(1.0)
+
+    sqrt_weights = torch.sqrt(weights)
+    inv_sqrt_edge_degree = torch.rsqrt(edge_degree)
+
+    scaled_incidence = incidence * (sqrt_weights * inv_sqrt_edge_degree).unsqueeze(0)
+    adjacency = scaled_incidence @ scaled_incidence.t()
+    adjacency.fill_diagonal_(0.0)
+
+    inv_sqrt_node_degree = torch.rsqrt(node_degree)
+    adjacency = (
+        inv_sqrt_node_degree.unsqueeze(1) * adjacency * inv_sqrt_node_degree.unsqueeze(0)
+    )
+    adjacency = adjacency + torch.eye(num_nodes, device=device, dtype=dtype)
+    return adjacency
+
+
+def zero_gate(reference: Tensor) -> Tensor:
+    """Return a gate tensor that keeps the trainer regularisers well-defined."""
+    return reference.new_zeros(reference.shape)
+
+
+__all__ = [
+    "aggregate_edges",
+    "aggregate_nodes",
+    "fuse_features",
+    "hypergraph_normalised_adjacency",
+    "zero_gate",
+]

--- a/src/models/hypergcn.py
+++ b/src/models/hypergcn.py
@@ -1,0 +1,78 @@
+"""HyperGCN baseline with symmetric normalised diffusion."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from torch import Tensor, nn
+
+from .baseline_utils import fuse_features, hypergraph_normalised_adjacency, zero_gate
+
+
+@dataclass
+class HyperGCNConfig:
+    in_dim: int
+    det_dim: int
+    hidden_dim: int = 128
+    out_dim: int = 2
+    num_layers: int = 2
+    dropout: float = 0.2
+
+
+class _HyperGCNLayer(nn.Module):
+    def __init__(self, hidden_dim: int, dropout: float) -> None:
+        super().__init__()
+        self.linear = nn.Linear(hidden_dim, hidden_dim)
+        self.activation = nn.ReLU()
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(
+        self, node_embeddings: Tensor, incidence: Tensor, edge_weights: Tensor | None
+    ) -> Tensor:
+        adjacency = hypergraph_normalised_adjacency(
+            incidence, edge_weights, node_embeddings.dtype, node_embeddings.device
+        )
+        propagated = adjacency @ node_embeddings
+        updated = self.activation(self.linear(self.dropout(propagated)))
+        return updated
+
+
+class HyperGCN(nn.Module):
+    """HyperGCN baseline that shares DF-HGNN's training interface."""
+
+    def __init__(self, config: HyperGCNConfig) -> None:
+        super().__init__()
+        self.config = config
+        input_dim = config.in_dim + config.det_dim
+        if input_dim <= 0:
+            raise ValueError("HyperGCN requires at least one feature dimension")
+
+        self.input_proj = nn.Linear(input_dim, config.hidden_dim)
+        self.layers = nn.ModuleList(
+            [_HyperGCNLayer(config.hidden_dim, config.dropout) for _ in range(config.num_layers)]
+        )
+        self.dropout = nn.Dropout(config.dropout)
+        self.output = nn.Linear(config.hidden_dim, config.out_dim)
+
+    def forward(
+        self, x: Tensor, z: Tensor, incidence: Tensor, edge_weights: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        fused = fuse_features(x, z)
+        h = self.input_proj(fused)
+        for layer in self.layers:
+            h = layer(h, incidence, edge_weights)
+        h = self.dropout(h)
+        logits = self.output(h)
+        gate = zero_gate(h)
+        return logits, gate
+
+    def alignment_loss(self, x: Tensor, z: Tensor) -> Tensor:
+        reference = x if x is not None and x.numel() > 0 else z
+        if reference is None or reference.numel() == 0:
+            reference = next(self.parameters()).detach()
+        return reference.new_zeros(())
+
+    def gate_regularization(self, gate: Tensor) -> Tensor:
+        return gate.new_zeros(())
+
+
+__all__ = ["HyperGCN", "HyperGCNConfig"]

--- a/src/models/registry.py
+++ b/src/models/registry.py
@@ -2,9 +2,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Type
+from typing import Dict
 
+from .allset_transformer import AllSetTransformer, AllSetTransformerConfig
 from .df_hgnn import DFHGNN, DFHGNNConfig
+from .hypergcn import HyperGCN, HyperGCNConfig
+from .unignn import UniGNN, UniGNNConfig
 
 
 @dataclass
@@ -19,9 +22,11 @@ class ModelFactoryInput:
     lambda_align: float
     lambda_gate: float
     fusion_dim: int | None = None
+    extras: Dict[str, object] | None = None
 
 
 def create_model(name: str, config: ModelFactoryInput):
+    extras = config.extras or {}
     if name.lower() == "df_hgnn":
         df_config = DFHGNNConfig(
             in_dim=config.in_dim,
@@ -36,4 +41,36 @@ def create_model(name: str, config: ModelFactoryInput):
             fusion_dim=config.fusion_dim,
         )
         return DFHGNN(df_config)
+    if name.lower() == "allset_transformer":
+        model_config = AllSetTransformerConfig(
+            in_dim=config.in_dim,
+            det_dim=config.det_dim,
+            hidden_dim=config.hidden_dim,
+            out_dim=config.out_dim,
+            num_layers=int(extras.get("num_layers", 2)),
+            num_heads=int(extras.get("num_heads", 4)),
+            mlp_ratio=float(extras.get("mlp_ratio", 2.0)),
+            dropout=float(extras.get("dropout", config.dropout)),
+        )
+        return AllSetTransformer(model_config)
+    if name.lower() == "unignn":
+        model_config = UniGNNConfig(
+            in_dim=config.in_dim,
+            det_dim=config.det_dim,
+            hidden_dim=config.hidden_dim,
+            out_dim=config.out_dim,
+            num_layers=int(extras.get("num_layers", 2)),
+            dropout=float(extras.get("dropout", config.dropout)),
+        )
+        return UniGNN(model_config)
+    if name.lower() == "hypergcn":
+        model_config = HyperGCNConfig(
+            in_dim=config.in_dim,
+            det_dim=config.det_dim,
+            hidden_dim=config.hidden_dim,
+            out_dim=config.out_dim,
+            num_layers=int(extras.get("num_layers", 2)),
+            dropout=float(extras.get("dropout", config.dropout)),
+        )
+        return HyperGCN(model_config)
     raise ValueError(f"Unknown model name: {name}")

--- a/src/models/unignn.py
+++ b/src/models/unignn.py
@@ -1,0 +1,79 @@
+"""UniGNN baseline with DF-HGNN compatible interface."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from torch import Tensor, nn
+
+from .baseline_utils import aggregate_edges, aggregate_nodes, fuse_features, zero_gate
+
+
+@dataclass
+class UniGNNConfig:
+    in_dim: int
+    det_dim: int
+    hidden_dim: int = 128
+    out_dim: int = 2
+    num_layers: int = 2
+    dropout: float = 0.3
+
+
+class _UniGNNLayer(nn.Module):
+    def __init__(self, hidden_dim: int, dropout: float) -> None:
+        super().__init__()
+        self.edge_linear = nn.Linear(hidden_dim, hidden_dim)
+        self.node_linear = nn.Linear(hidden_dim, hidden_dim)
+        self.activation = nn.ReLU()
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(
+        self, node_embeddings: Tensor, incidence: Tensor, edge_weights: Tensor | None
+    ) -> Tensor:
+        edge_messages = aggregate_edges(node_embeddings, incidence, edge_weights)
+        edge_messages = self.activation(self.edge_linear(edge_messages))
+        node_messages = aggregate_nodes(edge_messages, incidence, edge_weights)
+        node_messages = self.activation(self.node_linear(node_messages))
+        updated = node_embeddings + self.dropout(node_messages)
+        return updated
+
+
+class UniGNN(nn.Module):
+    """Simplified UniGNN encoder with residual diffusion blocks."""
+
+    def __init__(self, config: UniGNNConfig) -> None:
+        super().__init__()
+        self.config = config
+        input_dim = config.in_dim + config.det_dim
+        if input_dim <= 0:
+            raise ValueError("UniGNN requires at least one feature dimension")
+
+        self.input_proj = nn.Linear(input_dim, config.hidden_dim)
+        self.layers = nn.ModuleList(
+            [_UniGNNLayer(config.hidden_dim, config.dropout) for _ in range(config.num_layers)]
+        )
+        self.dropout = nn.Dropout(config.dropout)
+        self.output = nn.Linear(config.hidden_dim, config.out_dim)
+
+    def forward(
+        self, x: Tensor, z: Tensor, incidence: Tensor, edge_weights: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        fused = fuse_features(x, z)
+        h = self.input_proj(fused)
+        for layer in self.layers:
+            h = layer(h, incidence, edge_weights)
+        h = self.dropout(h)
+        logits = self.output(h)
+        gate = zero_gate(h)
+        return logits, gate
+
+    def alignment_loss(self, x: Tensor, z: Tensor) -> Tensor:
+        reference = x if x is not None and x.numel() > 0 else z
+        if reference is None or reference.numel() == 0:
+            reference = next(self.parameters()).detach()
+        return reference.new_zeros(())
+
+    def gate_regularization(self, gate: Tensor) -> Tensor:
+        return gate.new_zeros(())
+
+
+__all__ = ["UniGNN", "UniGNNConfig"]

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -73,6 +73,17 @@ class DFHGNNTrainer:
         )
         in_dim = node_features.shape[1]
         det_dim = deterministic_features.shape[1]
+        reserved_keys = {
+            "name",
+            "hidden_dim",
+            "dropout",
+            "conv_type",
+            "chebyshev_order",
+            "lambda_align",
+            "lambda_gate",
+            "fusion_dim",
+        }
+        extras = {k: v for k, v in self.model_config.items() if k not in reserved_keys}
         model = create_model(
             name=self.model_config["name"],
             config=ModelFactoryInput(
@@ -86,6 +97,7 @@ class DFHGNNTrainer:
                 lambda_align=float(self.model_config.get("lambda_align", 0.1)),
                 lambda_gate=float(self.model_config.get("lambda_gate", 0.001)),
                 fusion_dim=self.model_config.get("fusion_dim"),
+                extras=extras,
             ),
         ).to(self.device)
 


### PR DESCRIPTION
## Summary
- implement AllSet Transformer, UniGNN, and HyperGCN baselines with a common DF-HGNN-style interface
- extend the model registry and trainer wiring to expose the new baselines and their hyperparameters
- add reusable Hydra configs and README notes for running and reproducing the new experiments

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dc80e80e8c8323904f80651092633a