### PR TITLE
Fix duplicate return_cache parameters in trainer

### DIFF
--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -219,7 +219,6 @@ class DFHGNNTrainer:
         labels: torch.Tensor,
         split_indices: Dict[str, torch.Tensor],
         return_cache: bool = False,
-        return_cache: bool = False,
     ) -> Union[Dict[str, float], Tuple[Dict[str, float], PredictionCache]]:
         model.eval()
         with torch.inference_mode():
@@ -262,7 +261,6 @@ class DFHGNNTrainer:
         splits: Dict[str, torch.Tensor],
         timestamps: Optional[torch.Tensor] = None,
 
-        return_cache: bool = False,
         return_cache: bool = False,
     ) -> Union[Dict[str, float], Tuple[Dict[str, float], PredictionCache]]:
         deterministic_features = self.feature_bank(


### PR DESCRIPTION
## Summary
- remove duplicate return_cache arguments from DFHGNNTrainer evaluation methods

## Testing
- python -m py_compile src/training/trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68dc9acf3d4083238bf76d2069dc764f