### PR TITLE
Fix AllSet attention memory usage and feature bank handling

### DIFF
--- a/src/models/allset_transformer.py
+++ b/src/models/allset_transformer.py
@@ -1,11 +1,23 @@
 """AllSet Transformer baseline for hypergraph learning."""
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
+import torch
 from torch import Tensor, nn
+from torch.nn import functional as F
 
 from .baseline_utils import aggregate_edges, fuse_features, zero_gate
+
+
+try:  # pragma: no-cover - older PyTorch releases may lack SDPA
+    from torch.nn.functional import scaled_dot_product_attention as _sdpa
+
+    _SDPA_AVAILABLE = True
+except ImportError:  # pragma: no cover - fall back to manual attention
+    _sdpa = None
+    _SDPA_AVAILABLE = False
 
 
 @dataclass
@@ -20,12 +32,73 @@ class AllSetTransformerConfig:
     dropout: float = 0.2
 
 
+class _CrossAttention(nn.Module):
+    """Memory-efficient multi-head attention between nodes and hyperedges."""
+
+    def __init__(self, hidden_dim: int, num_heads: int, dropout: float) -> None:
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError(
+                "Hidden dimension must be divisible by the number of heads: "
+                f"got hidden_dim={hidden_dim}, num_heads={num_heads}"
+            )
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.dropout = dropout
+        self.q_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.k_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.v_proj = nn.Linear(hidden_dim, hidden_dim)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim)
+
+    def forward(self, query: Tensor, key: Tensor, value: Tensor | None = None) -> Tensor:
+        if value is None:
+            value = key
+
+        squeeze_batch = query.dim() == 2
+        if squeeze_batch:
+            query = query.unsqueeze(0)
+            key = key.unsqueeze(0)
+            value = value.unsqueeze(0)
+        elif query.dim() != 3:
+            raise ValueError("Attention inputs must be 2D or 3D tensors")
+
+        batch_size, target_len, hidden_dim = query.shape
+        source_len = key.shape[1]
+
+        q = self.q_proj(query)
+        k = self.k_proj(key)
+        v = self.v_proj(value)
+
+        q = q.view(batch_size, target_len, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.view(batch_size, source_len, self.num_heads, self.head_dim).transpose(1, 2)
+        v = v.view(batch_size, source_len, self.num_heads, self.head_dim).transpose(1, 2)
+
+        if _SDPA_AVAILABLE:
+            attn = _sdpa(
+                q,
+                k,
+                v,
+                dropout_p=self.dropout if self.training and self.dropout > 0 else 0.0,
+            )
+        else:  # pragma: no cover - compatibility path for older PyTorch
+            scale = 1.0 / math.sqrt(self.head_dim)
+            scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+            weights = torch.softmax(scores, dim=-1)
+            if self.training and self.dropout > 0:
+                weights = F.dropout(weights, p=self.dropout)
+            attn = torch.matmul(weights, v)
+
+        attn = attn.transpose(1, 2).contiguous().view(batch_size, target_len, hidden_dim)
+        attn = self.out_proj(attn)
+        if squeeze_batch:
+            attn = attn.squeeze(0)
+        return attn
+
+
 class _AllSetTransformerBlock(nn.Module):
     def __init__(self, hidden_dim: int, num_heads: int, mlp_ratio: float, dropout: float) -> None:
         super().__init__()
-        self.attention = nn.MultiheadAttention(
-            embed_dim=hidden_dim, num_heads=num_heads, dropout=dropout, batch_first=True
-        )
+        self.attention = _CrossAttention(hidden_dim, num_heads, dropout)
         mlp_hidden = max(hidden_dim, int(hidden_dim * mlp_ratio))
         self.feedforward = nn.Sequential(
             nn.Linear(hidden_dim, mlp_hidden),
@@ -41,12 +114,7 @@ class _AllSetTransformerBlock(nn.Module):
         self, node_embeddings: Tensor, incidence: Tensor, edge_weights: Tensor | None
     ) -> Tensor:
         edge_embeddings = aggregate_edges(node_embeddings, incidence, edge_weights)
-        attn_output, _ = self.attention(
-            node_embeddings.unsqueeze(0),
-            edge_embeddings.unsqueeze(0),
-            edge_embeddings.unsqueeze(0),
-        )
-        attn_output = attn_output.squeeze(0)
+        attn_output = self.attention(node_embeddings, edge_embeddings)
         h = self.norm1(node_embeddings + self.dropout(attn_output))
         ff = self.feedforward(h)
         h = self.norm2(h + self.dropout(ff))

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -52,11 +52,7 @@ class DFHGNNTrainer:
     ) -> None:
         self.trainer_config = trainer_config
         self.feature_config = feature_config
-        self.feature_bank = (
-            DeterministicFeatureBank(feature_config)
-            if feature_config.enabled
-            else None
-        )
+        self.feature_bank = DeterministicFeatureBank(feature_config)
         self.optimizer_config = optimizer_config
         self.metrics = metrics
         self.device = get_device(trainer_config.device)


### PR DESCRIPTION
## Summary
- replace the AllSet Transformer cross attention with a memory-efficient implementation that can leverage scaled dot product attention when available
- always initialise the deterministic feature bank so configurations without engineered features no longer crash at runtime

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc9f1115648323b52148a76cce7d41